### PR TITLE
Add Sentry integration

### DIFF
--- a/metabolic_ninja/__init__.py
+++ b/metabolic_ninja/__init__.py
@@ -1,0 +1,14 @@
+import logging
+
+from raven import Client
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
+
+# Configure Raven to capture warning logs
+raven_client = Client(settings.SENTRY_DSN)
+handler = SentryHandler(raven_client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)

--- a/metabolic_ninja/app.py
+++ b/metabolic_ninja/app.py
@@ -13,6 +13,7 @@ from pymongo import MongoClient, ASCENDING
 from metabolic_ninja.pathway_graph import PathwayGraph
 from metabolic_ninja.mongo_client import MongoDB, PathwayCollection, MONGO_CRED
 from metabolic_ninja.pickle_predictors import get_predictor
+from metabolic_ninja.middleware import raven_middleware
 
 
 logging.basicConfig()
@@ -184,7 +185,7 @@ async def ws_handler(request):
     return ws
 
 
-app = web.Application()
+app = web.Application(middlewares=[raven_middleware])
 API_PREFIX = '/pathways'
 LISTS_PREFIX = API_PREFIX + '/lists'
 app.router.add_route('GET', API_PREFIX + '/predict', run_predictor)

--- a/metabolic_ninja/middleware.py
+++ b/metabolic_ninja/middleware.py
@@ -1,0 +1,12 @@
+from . import raven_client
+
+
+async def raven_middleware(app, handler):
+    """aiohttp middleware which captures any uncaught exceptions to Sentry before re-raising"""
+    async def middleware_handler(request):
+        try:
+            return await handler(request)
+        except Exception:
+            raven_client.captureException()
+            raise
+    return middleware_handler

--- a/metabolic_ninja/settings.py
+++ b/metabolic_ninja/settings.py
@@ -1,0 +1,3 @@
+import os
+
+SENTRY_DSN = os.environ.get('SENTRY_DSN', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ gunicorn
 uvloop
 pytest-cov==2.4.0
 codecov
+raven==6.4.0


### PR DESCRIPTION
Adds Raven to capture error events to Sentry

- aiohttp middleware logs uncaught exceptions, and re-raises
- log events of `warning` or higher level